### PR TITLE
add player rating was not being shown.

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -147,11 +147,11 @@ switch($_POST['ajaxMethod'])
 
 		  if($ratingExists == "true")
 		  {
-			  echo "true";
+			  echo "1";
 		  }
 		  else
 		  {
-			echo "false";
+			echo "0";
 		  }
 		}
 

--- a/javascript/scripts.js
+++ b/javascript/scripts.js
@@ -943,7 +943,8 @@ function setInitialRating(playerID) {
                 ajaxMethod: "initial-rating-Manager"
             },
             success: function(data) {
-                if (data == "false") {
+                if (!parseInt(data)) {
+					//player as no rating for this sport set.
                     showInitialRatingModal(playerID, sportID);
                 }
             }


### PR DESCRIPTION
Somehow along the way a carriage return has started being outputted at the start of files. Usually not a problem but in this case because json encoding wasn't being used it was a problem. Resolved by changing outputs to integers